### PR TITLE
bcc_elf: mkostemp() requires _GNU_SOURCE

### DIFF
--- a/src/cc/bcc_elf.c
+++ b/src/cc/bcc_elf.c
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/mman.h>


### PR DESCRIPTION
As per [mkostemps(3)](https://manpages.debian.org/bullseye/manpages-dev/mkostemps.3.en.html), mkostemp() (used in [line 842](https://github.com/luisgerhorst/bcc/blob/026aaff1e21de198c68cf5ca9819e595cd30232d/src/cc/bcc_elf.c#L842)) requires _GNU_SOURCE. Therefore define it before the includes if it not defined by the env/compiler. Otherwise I encounter the following error on my system:

```
...
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /.../pyroscope/third_party/bcc/src/build
make[3]: Entering directory `/.../pyroscope/third_party/bcc/src/build'
make[4]: Entering directory `/.../pyroscope/third_party/bcc/src/build'
make[5]: Entering directory `/.../pyroscope/third_party/bcc/src/build'
make[5]: Entering directory `/.../pyroscope/third_party/bcc/src/build'
make[5]: Leaving directory `/.../pyroscope/third_party/bcc/src/build'
make[5]: Leaving directory `/.../pyroscope/third_party/bcc/src/build'
make[5]: Entering directory `/.../pyroscope/third_party/bcc/src/build'
make[5]: Entering directory `/.../pyroscope/third_party/bcc/src/build'
[  8%] Building CXX object CMakeFiles/bcc-syms.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_syms.o
[ 16%] Building C object CMakeFiles/bcc-syms-static.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.o
[ 25%] Building C object CMakeFiles/bcc-syms-static.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_perf_map.o
[ 33%] Building C object CMakeFiles/bcc-syms-static.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_proc.o
[ 41%] Building CXX object CMakeFiles/bcc-syms-static.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_syms.o
[ 50%] Building C object CMakeFiles/bcc-syms.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.o
[ 58%] Building C object CMakeFiles/bcc-syms.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_perf_map.o
[ 66%] Building CXX object CMakeFiles/bcc-syms-static.dir/.../pyroscope/third_party/bcc/src/src/cc/common.o
[ 75%] Building C object CMakeFiles/bcc-syms.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_proc.o
[ 83%] Building CXX object CMakeFiles/bcc-syms.dir/.../pyroscope/third_party/bcc/src/src/cc/common.o
/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.c:839:8: error: call to undeclared function 'mkostemp'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  fd = mkostemp(tmpfile, O_CLOEXEC);
       ^
/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.c:839:8: note: did you mean 'mkstemp'?
/usr/include/stdlib.h:570:12: note: 'mkstemp' declared here
extern int mkstemp (char *__template) __nonnull ((1)) __wur;
           ^
/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.c:839:8: error: call to undeclared function 'mkostemp'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  fd = mkostemp(tmpfile, O_CLOEXEC);
       ^
/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.c:839:8: note: did you mean 'mkstemp'?
/usr/include/stdlib.h:570:12: note: 'mkstemp' declared here
extern int mkstemp (char *__template) __nonnull ((1)) __wur;
           ^
1 error generated.
make[5]: *** [CMakeFiles/bcc-syms-static.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.o] Error 1
make[5]: *** Waiting for unfinished jobs....
1 error generated.
make[5]: *** [CMakeFiles/bcc-syms.dir/.../pyroscope/third_party/bcc/src/src/cc/bcc_elf.o] Error 1
make[5]: *** Waiting for unfinished jobs....
make[5]: Leaving directory `/.../pyroscope/third_party/bcc/src/build'
make[4]: *** [CMakeFiles/bcc-syms.dir/all] Error 2
make[4]: *** Waiting for unfinished jobs....
make[5]: Leaving directory `/.../pyroscope/third_party/bcc/src/build'
make[4]: *** [CMakeFiles/bcc-syms-static.dir/all] Error 2
make[4]: Leaving directory `/.../pyroscope/third_party/bcc/src/build'
make[3]: *** [all] Error 2
make[3]: Leaving directory `/.../pyroscope/third_party/bcc/src/build'
make[2]: *** [build-bcc] Error 2
make[2]: Leaving directory `/.../pyroscope/third_party/bcc'
make[1]: *** [build-bcc] Error 2
```

I noticed that this is [still not fixed in upstream bcc v0.27](https://github.com/iovisor/bcc/blob/046eea8f64f3dd7bf3a706fabadd8a66eeebb728/src/cc/bcc_elf.c#L35). However, updating (and rebasing) the bcc version used by pyroscope caused a buch of other errors on my system. Should I instead upstream the fix and then create a pull request to update the bcc version used by pyroscope?